### PR TITLE
Feat: Add  envs to pyfltye register

### DIFF
--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -129,7 +129,7 @@ def key_value_callback(_: typing.Any, param: str, values: typing.List[str]) -> t
     "--envs",
     "envs",
     required=False,
-    multiple=True,
+    # multiple=True,
     default="",
     type=str,
     callback=key_value_callback,

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -10,6 +10,7 @@ from flytekit.configuration import ImageConfig
 from flytekit.configuration.default_images import DefaultImages
 from flytekit.loggers import cli_logger
 from flytekit.tools import repo
+import json
 
 _register_help = """
 This command is similar to ``package`` but instead of producing a zip file, all your Flyte entities are compiled,
@@ -24,19 +25,27 @@ This means that a zip is created from the detected root of the packages given an
 Note: This command only works on regular Python packages, not namespace packages. When determining
 the root of your project, it finds the first folder that does not have a ``__init__.py`` file.
 """
-def key_value_callback(_: typing.Any, param: str, values: typing.List[str]) -> typing.Optional[typing.Dict[str, str]]:
-    """
-    Callback for click to parse key-value pairs.
-    """
-    if not values:
+# def key_value_callback(_: typing.Any, param: str, values: typing.List[str]) -> typing.Optional[typing.Dict[str, str]]:
+#     """
+#     Callback for click to parse key-value pairs.
+#     """
+#     if not values:
+#         return None
+#     result = {}
+#     for v in values:
+#         if "=" not in v:
+#             raise click.BadParameter(f"Expected key-value pair of the form key=value, got {v}")
+#         k, v = v.split("=", 1)
+#         result[k.strip()] = v.strip()
+#     return result
+
+def convert_envs(_: typing.Any, param: str, envs: str):
+    if not envs:
         return None
-    result = {}
-    for v in values:
-        if "=" not in v:
-            raise click.BadParameter(f"Expected key-value pair of the form key=value, got {v}")
-        k, v = v.split("=", 1)
-        result[k.strip()] = v.strip()
-    return result
+    print(_)
+    print(param)
+    print(json.loads(envs))
+    return json.loads(envs)
 
 @click.command("register", help=_register_help)
 @click.option(
@@ -130,9 +139,9 @@ def key_value_callback(_: typing.Any, param: str, values: typing.List[str]) -> t
     "envs",
     required=False,
     # multiple=True,
-    default="",
-    type=str,
-    callback=key_value_callback,
+    # default="",
+    # type=str,
+    callback=convert_envs,
     help="Environment variables to set in the container",
 )
 @click.argument("package-or-module", type=click.Path(exists=True, readable=True, resolve_path=True), nargs=-1)
@@ -151,7 +160,7 @@ def register(
     non_fast: bool,
     package_or_module: typing.Tuple[str],
     dry_run: bool,
-    envs: typing.Optional[str],
+    envs: typing.Optional[typing.Dict[str, str]] = None,
 ):
     """
     see help

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -25,26 +25,10 @@ This means that a zip is created from the detected root of the packages given an
 Note: This command only works on regular Python packages, not namespace packages. When determining
 the root of your project, it finds the first folder that does not have a ``__init__.py`` file.
 """
-# def key_value_callback(_: typing.Any, param: str, values: typing.List[str]) -> typing.Optional[typing.Dict[str, str]]:
-#     """
-#     Callback for click to parse key-value pairs.
-#     """
-#     if not values:
-#         return None
-#     result = {}
-#     for v in values:
-#         if "=" not in v:
-#             raise click.BadParameter(f"Expected key-value pair of the form key=value, got {v}")
-#         k, v = v.split("=", 1)
-#         result[k.strip()] = v.strip()
-#     return result
 
 def convert_envs(_: typing.Any, param: str, envs: str):
     if not envs:
         return None
-    print(_)
-    print(param)
-    print(json.loads(envs))
     return json.loads(envs)
 
 @click.command("register", help=_register_help)
@@ -138,9 +122,6 @@ def convert_envs(_: typing.Any, param: str, envs: str):
     "--envs",
     "envs",
     required=False,
-    # multiple=True,
-    # default="",
-    # type=str,
     callback=convert_envs,
     help="Environment variables to set in the container",
 )

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -3,7 +3,6 @@ import tarfile
 import tempfile
 import typing
 from pathlib import Path
-import json
 
 import click
 
@@ -218,7 +217,6 @@ def register(
     fast: bool,
     package_or_module: typing.Tuple[str],
     remote: FlyteRemote,
-    # envs: typing.Optional[typing.Dict[str, str]],
     envs: typing.Optional[str],
     dry_run: bool = False,
 ):
@@ -241,7 +239,7 @@ def register(
         version=version,
         image_config=image_config,
         fast_serialization_settings=fast_serialization_settings,
-        env=envs, #json.loads(envs),
+        env=envs,
     )
 
     if not version and fast:

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -3,6 +3,7 @@ import tarfile
 import tempfile
 import typing
 from pathlib import Path
+import json
 
 import click
 
@@ -217,6 +218,7 @@ def register(
     fast: bool,
     package_or_module: typing.Tuple[str],
     remote: FlyteRemote,
+    # envs: typing.Optional[typing.Dict[str, str]],
     envs: typing.Optional[str],
     dry_run: bool = False,
 ):
@@ -239,7 +241,7 @@ def register(
         version=version,
         image_config=image_config,
         fast_serialization_settings=fast_serialization_settings,
-        env=envs,
+        env=envs, #json.loads(envs),
     )
 
     if not version and fast:

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -217,6 +217,7 @@ def register(
     fast: bool,
     package_or_module: typing.Tuple[str],
     remote: FlyteRemote,
+    envs: typing.Optional[str],
     dry_run: bool = False,
 ):
     detected_root = find_common_root(package_or_module)
@@ -238,6 +239,7 @@ def register(
         version=version,
         image_config=image_config,
         fast_serialization_settings=fast_serialization_settings,
+        env=envs,
     )
 
     if not version and fast:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup  # noqa
 
 extras_require = {}
 
-__version__ = "1.6.0+add-token-caching"
+__version__ = "dev-envs-register"
 
 setup(
     name="flytekit",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup  # noqa
 
 extras_require = {}
 
-__version__ = "dev-envs-register"
+__version__ = "1.6.0+add-envs-register"
 
 setup(
     name="flytekit",


### PR DESCRIPTION
Adds compatiblity with --envs flag in `pyflyte register`

Depends on CronParser class as defined below being defined in workflow.py files and/or whatever python files you are using to invoke pyflyte.

```
class CronParser:
    """
    Defined in launchplan module as Cron statements are unable to be parsed
    correctly due to JSON.Decode errors.

    Incompatibility stems from Pyflyte, Python, or JSON module level
    """
    def __init__(self):
        self.replacements = {
            "*": "a",
            "?": "b",
            ",": "c",
            "-": "d",
            "/": "e",
            " ": "f"
        }

    def cron_to_string(self, cron: str) -> str:
        """
        Convert input cron statement into Flyte compatible string
        """
        return re.sub(r"[*?,\-/\s]", lambda m: self.replacements[m.group()], cron)

    def string_to_cron(self, x: str) -> str:
        """
        Convert input string into cron statement. Used for launchplan config
        """
        return re.sub(r"[abcdef]", lambda m: {v: k for k, v in self.replacements.items()}[m.group()], x)

```

Probably best to integrate this with Flytekit repo itself but time constraints dictate this is the fastest approach.